### PR TITLE
[Feat:] Added Back button functionality

### DIFF
--- a/src/app/dashboard/page.jsx
+++ b/src/app/dashboard/page.jsx
@@ -7,6 +7,8 @@ import FormGroup from "@mui/material/FormGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import AddIcon from "@mui/icons-material/Add";
 import { redirect } from "next/navigation";
+import Link from "next/link";
+import ArrowBackIosNewRoundedIcon from '@mui/icons-material/ArrowBackIosNewRounded';
 
 import { SignedIn, UserButton } from "@clerk/nextjs";
 
@@ -17,6 +19,15 @@ export default function page() {
   return (
     <div className="h-full flex">
       <div className="flex flex-col justify-between basis-1/12 pt-28 bg-[#FFFFFF05] border-r-2 border-[#FFFFFF20]">
+      <Link href="/" className="mx-auto">
+      <ArrowBackIosNewRoundedIcon 
+       sx={
+        { fontSize: 60,
+          color: "white"
+        }
+      }
+      />
+      </Link>
         <div className="flex justify-center items-center"></div>
         <div className="flex justify-center items-center">
           {/* <SignedIn>


### PR DESCRIPTION
## Description
Provided a back button functionality in the sidebar of dashboard, which redirects to home page

### Method Adopted:
- Modified the src/app/dashboard/page.jsx file.
- Used a Link to direct from Dashboard page to Home page.
- Used "ArrowBackIosNewRoundedIcon" from Material UI as a displaying Icon.
 
### Resolved 
- Removed unnecessary import for button.
- No code conflict

#### Here is how it looks:![Screenshot 2024-05-20 123814](https://github.com/Arindam200/makaut_buddy/assets/145017372/37badff3-c0a4-477d-9530-9a86cef36bb6)