### PR TITLE
fix: Removed the "Add Resources" button from the right side of the dashboard

### DIFF
--- a/src/app/dashboard/page.jsx
+++ b/src/app/dashboard/page.jsx
@@ -61,15 +61,6 @@ export default function Page() {
       <p className="text-gray-400 text-center max-w-md text-sm">
         It looks like there are no resources available at the moment. Check back later or try adjusting your filters.
       </p>
-      {isAdmin && (
-        <button
-          onClick={() => setStartUpload(true)}
-          className="mt-4 bg-white hover:bg-gray-200 text-black font-semibold py-2 px-4 rounded-md flex items-center text-sm"
-        >
-          <AddIcon className="mr-2" />
-          Add Resources
-        </button>
-      )}
     </div>
   );
 


### PR DESCRIPTION
## Description
This PR addresses the issue of having two "Add Resources" buttons on the dashboard, which creates inconsistency and affects the visual appeal, especially when no resources are present in any section. To improve the user interface and maintain consistency, we are removing the "Add Resources" button from the right side of the dashboard

## Changes
- Removed the redundant "Add Resources" button from the right side of the dashboard
- Ensured that only one "Add Resources" button remains and consistency is maintained


## Screenshots
Dashboard after the change:
![image](https://github.com/user-attachments/assets/1a8d0bd2-2adf-4f8a-925c-45e21db51e11)

Fixes: #169 

